### PR TITLE
fix: 비동기 스케쥴링 간 스케쥴러 레이스컨디션

### DIFF
--- a/src/main/java/io/codef/api/ResponseHandler.java
+++ b/src/main/java/io/codef/api/ResponseHandler.java
@@ -1,39 +1,57 @@
 package io.codef.api;
 
-import static io.codef.api.dto.EasyCodefRequest.ACCESS_TOKEN;
-import static io.codef.api.dto.EasyCodefResponse.DATA;
-import static io.codef.api.dto.EasyCodefResponse.RESULT;
-
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
+import io.codef.api.constants.CodefResponseCode;
 import io.codef.api.dto.EasyCodefResponse;
 import io.codef.api.error.CodefError;
 import io.codef.api.error.CodefException;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.http.HttpStatus;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+import static io.codef.api.dto.EasyCodefRequest.ACCESS_TOKEN;
+import static io.codef.api.dto.EasyCodefResponse.DATA;
+import static io.codef.api.dto.EasyCodefResponse.RESULT;
 
 public class ResponseHandler {
 
     private static final String UTF_8 = StandardCharsets.UTF_8.toString();
+
+    public static boolean isSuccessResponse(EasyCodefResponse response) {
+        return CodefResponseCode.CF_00000.equals(response.code());
+    }
+
+    public static boolean isAddAuthResponse(EasyCodefResponse response) {
+        return CodefResponseCode.CF_03002.equals(response.code());
+    }
+
+    public static boolean isAddAuthExceedResponse(EasyCodefResponse response) {
+        return CodefResponseCode.CF_12872.equals(response.code());
+    }
+
+    public static boolean isFailureResponse(EasyCodefResponse response) {
+        return !isSuccessResponse(response) && !isAddAuthResponse(response);
+    }
 
     /**
      * 토큰 응답 처리
      */
     public String handleTokenResponse(ClassicHttpResponse response) throws CodefException {
         return handleHttpResponse(
-            response,
-            this::parseAccessToken,
-            CodefError.OAUTH_UNAUTHORIZED,
-            CodefError.OAUTH_INTERNAL_ERROR,
-            false
+                response,
+                this::parseAccessToken,
+                CodefError.OAUTH_UNAUTHORIZED,
+                CodefError.OAUTH_INTERNAL_ERROR,
+                false
         );
     }
 
@@ -41,13 +59,13 @@ public class ResponseHandler {
      * 상품 응답 처리
      */
     public EasyCodefResponse handleProductResponse(ClassicHttpResponse response)
-        throws CodefException {
+            throws CodefException {
         return handleHttpResponse(
-            response,
-            this::parseProductResponse,
-            CodefError.CODEF_API_UNAUTHORIZED,
-            CodefError.CODEF_API_SERVER_ERROR,
-            true
+                response,
+                this::parseProductResponse,
+                CodefError.CODEF_API_UNAUTHORIZED,
+                CodefError.CODEF_API_SERVER_ERROR,
+                true
         );
     }
 
@@ -55,18 +73,17 @@ public class ResponseHandler {
      * 공통 HTTP 응답 처리 로직
      */
     private <T> T handleHttpResponse(
-        ClassicHttpResponse response,
-        Function<String, T> parser,
-        CodefError unauthorizedError,
-        CodefError defaultError,
-        boolean requireUrlDecoding
+            ClassicHttpResponse response,
+            Function<String, T> parser,
+            CodefError unauthorizedError,
+            CodefError defaultError,
+            boolean requireUrlDecoding
     ) throws CodefException {
         String responseBody = extractResponseBody(response, requireUrlDecoding);
 
         return switch (response.getCode()) {
             case HttpStatus.SC_OK -> parser.apply(responseBody);
-            case HttpStatus.SC_UNAUTHORIZED ->
-                throw CodefException.of(unauthorizedError, responseBody);
+            case HttpStatus.SC_UNAUTHORIZED -> throw CodefException.of(unauthorizedError, responseBody);
             default -> throw CodefException.of(defaultError, responseBody);
         };
     }
@@ -75,7 +92,7 @@ public class ResponseHandler {
      * HTTP 응답 본문 추출
      */
     private String extractResponseBody(ClassicHttpResponse response, boolean requiresDecoding)
-        throws CodefException {
+            throws CodefException {
         try {
             String responseBody = EntityUtils.toString(response.getEntity());
             return requiresDecoding ? URLDecoder.decode(responseBody, UTF_8) : responseBody;
@@ -115,8 +132,8 @@ public class ResponseHandler {
 
     private EasyCodefResponse.Result parseResult(JSONObject jsonResponse) throws CodefException {
         return Optional.ofNullable(jsonResponse.getJSONObject(RESULT))
-            .map(object -> object.to(EasyCodefResponse.Result.class))
-            .orElseThrow(() -> CodefException.from(CodefError.PARSE_ERROR));
+                .map(object -> object.to(EasyCodefResponse.Result.class))
+                .orElseThrow(() -> CodefException.from(CodefError.PARSE_ERROR));
     }
 
     private Object parseData(JSONObject jsonResponse) throws CodefException {
@@ -129,13 +146,13 @@ public class ResponseHandler {
 
     private Object parseObjectData(JSONObject jsonResponse) throws CodefException {
         return Optional.ofNullable(jsonResponse.getJSONObject(DATA))
-            .map(obj -> obj.to(Object.class))
-            .orElseThrow(() -> CodefException.from(CodefError.PARSE_ERROR));
+                .map(obj -> obj.to(Object.class))
+                .orElseThrow(() -> CodefException.from(CodefError.PARSE_ERROR));
     }
 
     private List<?> parseArrayData(JSONObject jsonResponse) throws CodefException {
         return Optional.ofNullable(jsonResponse.getJSONArray(DATA))
-            .map(obj -> obj.to(List.class))
-            .orElseThrow(() -> CodefException.from(CodefError.PARSE_ERROR));
+                .map(obj -> obj.to(List.class))
+                .orElseThrow(() -> CodefException.from(CodefError.PARSE_ERROR));
     }
 }

--- a/src/main/java/io/codef/api/ResponseLogger.java
+++ b/src/main/java/io/codef/api/ResponseLogger.java
@@ -1,0 +1,101 @@
+package io.codef.api;
+
+import com.alibaba.fastjson2.JSON;
+import io.codef.api.dto.EasyCodefResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.codef.api.constants.CodefResponseCode.*;
+
+public class ResponseLogger {
+    private static final Logger log = LoggerFactory.getLogger(ResponseLogger.class);
+
+    private ResponseLogger() {
+    }
+
+
+    public static void logResponseStatus(EasyCodefResponse response) {
+        logBasicInfo(response);
+
+        switch (response.code()) {
+            case CF_00000:
+                logSuccessResponse();
+                break;
+
+            case CF_03002:
+                logAddAuthRequired(response);
+                break;
+
+            case CF_12872:
+                logAuthExceeded();
+                break;
+
+            default:
+                logError(response);
+                break;
+        }
+    }
+
+    public static void logStatusSummary(List<EasyCodefResponse> responses) {
+        long successCount = responses.stream().filter(ResponseHandler::isSuccessResponse).count();
+        long addAuthCount = responses.stream().filter(ResponseHandler::isAddAuthResponse).count();
+        long failureCount = responses.stream().filter(ResponseHandler::isFailureResponse).count();
+
+        log.info("Total Responses Count = {}\n", responses.size());
+        logStatus(successCount, addAuthCount, failureCount);
+    }
+
+    private static void logBasicInfo(EasyCodefResponse response) {
+        log.info("Response Status Code : {}", response.code());
+        log.info("Transaction Id : {}", response.transactionId());
+    }
+
+    private static void logSuccessResponse() {
+        log.info("Successfully returned Value from Codef API\n");
+    }
+
+    private static void logAddAuthRequired(EasyCodefResponse response) {
+        Object data = response.data();
+        String addAuthMethod = JSON.parseObject(data.toString()).getString("method");
+        log.warn("Additional authentication required | method : {}\n", addAuthMethod);
+    }
+
+    private static void logAuthExceeded() {
+        log.error("Retry limit for additional authentication exceeded. "
+                + "Please restart the process from the initial request.\n");
+    }
+
+    private static void logError(EasyCodefResponse response) {
+        log.error("Failed to get proper scrapping response. Check the Error errorMessage And StatusCode");
+        log.error("> message : {}", response.result().message());
+        log.error("> extraMessage : {}", response.result().extraMessage());
+    }
+
+    private static void logStatus(
+            long successCount,
+            long addAuthCount,
+            long failureCount
+    ) {
+        Optional.of(successCount)
+                .filter(ResponseLogger::isExist)
+                .ifPresent(count -> log.info("Success Response Status [ {} ] Count : {}", CF_00000, count));
+
+        Optional.of(addAuthCount)
+                .filter(ResponseLogger::isExist)
+                .ifPresent(count -> log.info("AddAuth Response Status [ {} ] Count : {}", CF_03002, count));
+
+        Optional.of(failureCount)
+                .filter(ResponseLogger::isExist)
+                .ifPresentOrElse(
+                        count -> log.warn("Failure Response Status [   Else   ] Count : {}\n", count),
+                        () -> log.info("No Failure Responses\n")
+                );
+    }
+
+    private static boolean isExist(Long count) {
+        return count > 0;
+    }
+}

--- a/src/main/java/io/codef/api/facade/SimpleAuthCertFacade.java
+++ b/src/main/java/io/codef/api/facade/SimpleAuthCertFacade.java
@@ -140,7 +140,7 @@ public class SimpleAuthCertFacade {
 
         log.info("Success Response Status [CF-00000] Count : {}", successCount);
         log.info("AddAuth Response Status [CF-03002] Count : {}", addAuthCount);
-        log.warn("Failure Response Status [  Else  ] Count : {}", failureCount);
+        log.warn("Failure Response Status [  Else  ] Count : {}\n", failureCount);
 
         if (failureCount > 0) {
             responses.stream()

--- a/src/main/java/io/codef/api/facade/SimpleAuthCertFacade.java
+++ b/src/main/java/io/codef/api/facade/SimpleAuthCertFacade.java
@@ -1,22 +1,20 @@
 package io.codef.api.facade;
 
-import static io.codef.api.constants.CodefResponseCode.CF_03002;
-import static io.codef.api.constants.CodefResponseCode.CF_12872;
-import static io.codef.api.dto.EasyCodefRequest.TRUE;
-
-import com.alibaba.fastjson2.JSON;
-import io.codef.api.constants.CodefResponseCode;
+import io.codef.api.ResponseHandler;
+import io.codef.api.ResponseLogger;
 import io.codef.api.dto.EasyCodefRequest;
 import io.codef.api.dto.EasyCodefResponse;
 import io.codef.api.error.CodefException;
 import io.codef.api.storage.MultipleRequestStorage;
 import io.codef.api.storage.SimpleAuthStorage;
 import io.codef.api.vo.CodefSimpleAuth;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.codef.api.dto.EasyCodefRequest.TRUE;
 
 public class SimpleAuthCertFacade {
 
@@ -26,88 +24,36 @@ public class SimpleAuthCertFacade {
     private final SimpleAuthStorage simpleAuthStorage;
     private final MultipleRequestStorage multipleRequestStorage;
 
-    public SimpleAuthCertFacade(
-        SingleReqFacade singleReqFacade,
-        SimpleAuthStorage simpleAuthStorage,
-        MultipleRequestStorage multipleRequestStorage
-    ) {
+    public SimpleAuthCertFacade(SingleReqFacade singleReqFacade,
+        SimpleAuthStorage simpleAuthStorage, MultipleRequestStorage multipleRequestStorage) {
         this.singleReqFacade = singleReqFacade;
         this.simpleAuthStorage = simpleAuthStorage;
         this.multipleRequestStorage = multipleRequestStorage;
     }
 
-    public EasyCodefResponse requestSimpleAuthCertification(String transactionId) throws CodefException {
+    public EasyCodefResponse requestSimpleAuthCertification(String transactionId)
+        throws CodefException {
         CodefSimpleAuth simpleAuth = simpleAuthStorage.get(transactionId);
         EasyCodefRequest enrichedRequest = enrichRequestWithTwoWayInfo(simpleAuth);
         EasyCodefResponse response = singleReqFacade.requestProduct(enrichedRequest);
 
-        simpleAuthStorage.updateIfRequired(
-            simpleAuth.requestUrl(),
-            enrichedRequest,
-            response,
-            transactionId
-        );
+        simpleAuthStorage.updateIfRequired(simpleAuth.requestUrl(), enrichedRequest, response);
 
-        logResponseStatus(response, transactionId);
+        ResponseLogger.logResponseStatus(response);
         return response;
     }
 
-    public List<EasyCodefResponse> requestMultipleSimpleAuthCertification(
-        String transactionId
-    ) throws CodefException {
+    public List<EasyCodefResponse> requestMultipleSimpleAuthCertification(String transactionId)
+        throws CodefException {
         EasyCodefResponse firstResponse = requestSimpleAuthCertification(transactionId);
 
-        return isSuccessResponse(firstResponse)
+        return ResponseHandler.isSuccessResponse(firstResponse)
             ? combineWithRemainingResponses(firstResponse, transactionId)
             : returnFirstResponse(firstResponse);
     }
 
-    private void logAddAuthResponseStatus(
-        EasyCodefResponse response,
-        String resultStatusCode
-    ) {
-        if (resultStatusCode.equals(CF_03002)) {
-            Object data = response.data();
-            String addAuthMethod = JSON.parseObject(data.toString()).getString("method");
-
-            log.warn("Additional authentication required | method : {}\n", addAuthMethod);
-        } else if (resultStatusCode.equals(CF_12872)) {
-            log.warn(
-                "Retry limit for additional authentication exceeded. "
-                + "Please restart the process from the initial request.\n"
-            );
-        }
-    }
-
-    private void logDefaultResponseStatus(String transactionId, String resultStatusCode) {
-        log.info("Result Status Code : {}", resultStatusCode);
-        log.info("Transaction Id : {}", transactionId);
-    }
-
-    private void logResponseStatus(
-        EasyCodefResponse response,
-        String transactionId
-    ) {
-        String resultStatusCode = response.code();
-        logDefaultResponseStatus(transactionId, resultStatusCode);
-
-        logAddAuthResponseStatus(response, resultStatusCode);
-    }
-
     private List<EasyCodefResponse> returnFirstResponse(EasyCodefResponse firstErrorResponse) {
         return List.of(firstErrorResponse);
-    }
-
-    private boolean isSuccessResponse(EasyCodefResponse response) {
-        return CodefResponseCode.CF_00000.equals(response.code());
-    }
-
-    private boolean isAddAuthResponse(EasyCodefResponse response) {
-        return CodefResponseCode.CF_03002.equals(response.code());
-    }
-
-    private boolean isFailureResponse(EasyCodefResponse response) {
-        return !isSuccessResponse(response) && !isAddAuthResponse(response);
     }
 
     private EasyCodefRequest enrichRequestWithTwoWayInfo(CodefSimpleAuth simpleAuth) {
@@ -121,32 +67,13 @@ public class SimpleAuthCertFacade {
         return request;
     }
 
-    private List<EasyCodefResponse> combineWithRemainingResponses(EasyCodefResponse firstResponse,
-        String transactionId) throws CodefException {
-
-        log.info("Await Responses called By transactionId `{}`", transactionId);
-        List<EasyCodefResponse> responses = multipleRequestStorage.getRemainingResponses(
-            transactionId);
-        log.info("Await Responses Count = {}", responses.size());
-
+    private List<EasyCodefResponse> combineWithRemainingResponses(
+        EasyCodefResponse firstResponse,
+        String transactionId
+    ) throws CodefException {
+        List<EasyCodefResponse> responses = multipleRequestStorage.getRemainingResponses(transactionId);
         responses.add(firstResponse);
-        log.info("Total Responses Count = {}\n", responses.size());
-
-        long successCount = responses.stream().filter(this::isSuccessResponse).count();
-        long addAuthCount = responses.stream().filter(this::isAddAuthResponse).count();
-        long failureCount = responses.stream().filter(this::isFailureResponse).count();
-
-        log.info("Success Response Status [CF-00000] Count : {}", successCount);
-        log.info("AddAuth Response Status [CF-03002] Count : {}", addAuthCount);
-        log.warn("Failure Response Status [  Else  ] Count : {}\n", failureCount);
-
-        if (failureCount > 0) {
-            responses.stream()
-                .filter(this::isFailureResponse)
-                .map(EasyCodefResponse::code)
-                .collect(Collectors.groupingBy(code -> code, Collectors.counting()))
-                .forEach((code, count) -> log.warn("> Error code : {}, Count: {}", code, count));
-        }
+        ResponseLogger.logStatusSummary(responses);
 
         return responses;
     }

--- a/src/main/java/io/codef/api/facade/SimpleAuthCertFacade.java
+++ b/src/main/java/io/codef/api/facade/SimpleAuthCertFacade.java
@@ -64,7 +64,6 @@ public class SimpleAuthCertFacade {
 
     private void logAddAuthResponseStatus(
         EasyCodefResponse response,
-        String transactionId,
         String resultStatusCode
     ) {
         if (resultStatusCode.equals(CF_03002)) {
@@ -92,7 +91,7 @@ public class SimpleAuthCertFacade {
         String resultStatusCode = response.code();
         logDefaultResponseStatus(transactionId, resultStatusCode);
 
-        logAddAuthResponseStatus(response, transactionId, resultStatusCode);
+        logAddAuthResponseStatus(response, resultStatusCode);
     }
 
     private List<EasyCodefResponse> returnFirstResponse(EasyCodefResponse firstErrorResponse) {
@@ -131,7 +130,6 @@ public class SimpleAuthCertFacade {
         log.info("Await Responses Count = {}", responses.size());
 
         responses.add(firstResponse);
-        List<String> allResponseCodes = responses.stream().map(EasyCodefResponse::code).toList();
         log.info("Total Responses Count = {}\n", responses.size());
 
         long successCount = responses.stream().filter(this::isSuccessResponse).count();

--- a/src/main/java/io/codef/api/facade/SingleReqFacade.java
+++ b/src/main/java/io/codef/api/facade/SingleReqFacade.java
@@ -2,6 +2,7 @@ package io.codef.api.facade;
 
 import io.codef.api.EasyCodefConnector;
 import io.codef.api.EasyCodefToken;
+import io.codef.api.ResponseLogger;
 import io.codef.api.constants.CodefClientType;
 import io.codef.api.dto.EasyCodefRequest;
 import io.codef.api.dto.EasyCodefResponse;
@@ -31,7 +32,8 @@ public class SingleReqFacade {
         EasyCodefResponse response =
             EasyCodefConnector.requestProduct(request, validToken, requestUrl);
 
-        simpleAuthStorage.storeIfRequired(request, response, requestUrl);
+        simpleAuthStorage.storeIfAddAuthResponse(request, response, requestUrl);
+        ResponseLogger.logResponseStatus(response);
         return response;
     }
 

--- a/src/main/java/io/codef/api/storage/MultipleRequestStorage.java
+++ b/src/main/java/io/codef/api/storage/MultipleRequestStorage.java
@@ -5,16 +5,15 @@ import io.codef.api.dto.EasyCodefResponse;
 import io.codef.api.error.CodefError;
 import io.codef.api.error.CodefException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class MultipleRequestStorage {
 
-    private final Map<String, List<CompletableFuture<EasyCodefResponse>>> storage = new HashMap<>();
+    private final ConcurrentHashMap<String, List<CompletableFuture<EasyCodefResponse>>> storage = new ConcurrentHashMap<>();
 
     public List<EasyCodefResponse> getRemainingResponses(
         String transactionId

--- a/src/main/java/io/codef/api/storage/MultipleRequestStorage.java
+++ b/src/main/java/io/codef/api/storage/MultipleRequestStorage.java
@@ -4,6 +4,9 @@ import io.codef.api.CodefValidator;
 import io.codef.api.dto.EasyCodefResponse;
 import io.codef.api.error.CodefError;
 import io.codef.api.error.CodefException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -13,11 +16,14 @@ import java.util.stream.Collectors;
 
 public class MultipleRequestStorage {
 
+    private static final Logger log = LoggerFactory.getLogger(MultipleRequestStorage.class);
     private final ConcurrentHashMap<String, List<CompletableFuture<EasyCodefResponse>>> storage = new ConcurrentHashMap<>();
 
     public List<EasyCodefResponse> getRemainingResponses(
         String transactionId
     ) throws CodefException {
+        log.info("Await Responses called By transactionId `{}`", transactionId);
+
         final List<CompletableFuture<EasyCodefResponse>> futures = storage.get(transactionId);
         CodefValidator.requireNonNullElseThrow(futures, CodefError.SIMPLE_AUTH_FAILED);
 
@@ -34,6 +40,8 @@ public class MultipleRequestStorage {
                 .collect(Collectors.toCollection(ArrayList::new));
 
             storage.remove(transactionId);
+
+            log.info("Await Responses Count = {}", results.size());
             return results;
         } catch (Exception e) {
             throw CodefException.from(CodefError.SIMPLE_AUTH_FAILED);

--- a/src/main/java/io/codef/api/storage/SimpleAuthStorage.java
+++ b/src/main/java/io/codef/api/storage/SimpleAuthStorage.java
@@ -6,6 +6,7 @@ import io.codef.api.dto.EasyCodefResponse;
 import io.codef.api.error.CodefError;
 import io.codef.api.error.CodefException;
 import io.codef.api.vo.CodefSimpleAuth;
+
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -13,7 +14,7 @@ public class SimpleAuthStorage {
 
     private final ConcurrentHashMap<String, CodefSimpleAuth> storage = new ConcurrentHashMap<>();
 
-    public void storeIfRequired(
+    public void storeIfAddAuthResponse(
         EasyCodefRequest request,
         EasyCodefResponse response,
         String requestUrl
@@ -34,9 +35,10 @@ public class SimpleAuthStorage {
     public void updateIfRequired(
         String path,
         EasyCodefRequest request,
-        EasyCodefResponse response,
-        String transactionId
+        EasyCodefResponse response
     ) {
+        String transactionId = response.transactionId();
+
         Optional.ofNullable(response.code())
             .filter(code -> code.equals(CodefResponseCode.CF_03002))
             .ifPresentOrElse(

--- a/src/main/java/io/codef/api/storage/SimpleAuthStorage.java
+++ b/src/main/java/io/codef/api/storage/SimpleAuthStorage.java
@@ -6,13 +6,12 @@ import io.codef.api.dto.EasyCodefResponse;
 import io.codef.api.error.CodefError;
 import io.codef.api.error.CodefException;
 import io.codef.api.vo.CodefSimpleAuth;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SimpleAuthStorage {
 
-    private final Map<String, CodefSimpleAuth> storage = new HashMap<>();
+    private final ConcurrentHashMap<String, CodefSimpleAuth> storage = new ConcurrentHashMap<>();
 
     public void storeIfRequired(
         EasyCodefRequest request,
@@ -35,7 +34,8 @@ public class SimpleAuthStorage {
     public void updateIfRequired(
         String path,
         EasyCodefRequest request,
-        EasyCodefResponse response, String transactionId
+        EasyCodefResponse response,
+        String transactionId
     ) {
         Optional.ofNullable(response.code())
             .filter(code -> code.equals(CodefResponseCode.CF_03002))


### PR DESCRIPTION
기존 다건요청 0.7초 스케쥴러가 쓰레드 종속적으로 구현되면서,
다중 클라이언트 요청 환경에서 공유자원에 접근하면서 예외처리 발생.
0.7초 스케쥴링을 쓰레드 종속적이 아니라, 각 다건요청 별 0.7초 간격으로 요청하도록 구현