### PR TITLE
feat: requestObject 메소드 신규 개발 대응 및 불필요 메소드 제거

### DIFF
--- a/src/main/java/io/codef/api/EasyCodef.java
+++ b/src/main/java/io/codef/api/EasyCodef.java
@@ -54,6 +54,10 @@ public class EasyCodef {
         logInitializeSuccessfully();
     }
 
+    public String encryptRSA(String requestParam) throws CodefException {
+        return RsaUtil.encryptRSA(requestParam, publicKey);
+    }
+
     public EasyCodefResponse requestProduct(EasyCodefRequest request) throws CodefException {
         return singleReqFacade.requestProduct(request);
     }

--- a/src/main/java/io/codef/api/dto/EasyCodefRequest.java
+++ b/src/main/java/io/codef/api/dto/EasyCodefRequest.java
@@ -1,10 +1,10 @@
 package io.codef.api.dto;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public record EasyCodefRequest(
     String path,
-    HashMap<String, Object> requestBody
+    Map<String, Object> requestBody
 ) {
 
     /**


### PR DESCRIPTION
- requestObject 메소드 신규 개발
    - 커넥티드 아이디 등록과 같이 Object형 파라미터 상품 요청에 대응
- organization 메소드 제거
    - requestBody, requestObject에 모두 대응하기 위해 일관성을 위해 제거
- easyCodef.encryptrRSA() 메소드 신규 개발
    - secureWith(), secureRequestBody() 메소드 제거에 따른 대응